### PR TITLE
bcrypt - upgrade to 0.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "async": "^0.9.0",
-    "bcrypt": "^0.7.8",
+    "bcrypt": "^0.8.3",
     "passwordless-tokenstore": "0.0.10",
     "redis": "^0.10.3"
   },


### PR DESCRIPTION
Bcrypt doesn't compile under io.js with < 0.8, this PR simply upgrades to 0.8.3.
