### PR TITLE
Use default settings for port and host from redis

### DIFF
--- a/lib/redisstore.js
+++ b/lib/redisstore.js
@@ -19,22 +19,18 @@ var async = require('async');
  * @constructor
  */
 function RedisStore(port, host, options) {
-	port = port || 6379;
-	host = host || '127.0.0.1';
-	this._options = options || {};
-	this._options.redisstore = this._options.redisstore || {};
-	if(this._options.redisstore.database && !isNumber(this._options.redisstore.database)) {
+	var redisstoreOptions = options && options.redisstore ? options.redisstore : {};
+
+	if(redisstoreOptions.database && !isNumber(redisstoreOptions.database)) {
 		throw new Error('database has to be a number (if provided at all)');
-	} else if(this._options.redisstore.database) {
-		this._database = this._options.redisstore.database;
+	} else if(redisstoreOptions.database) {
+		this._database = redisstoreOptions.database;
 	} else {
 		this._database = 0;
 	}
+	this._tokenKey = redisstoreOptions.tokenkey || 'pwdless:';
 
-	this._tokenKey = this._options.redisstore.tokenkey || 'pwdless:';
-	delete this._options.redisstore;
-
-	this._client = redis.createClient(port, host, this._options);
+	this._client = redis.createClient(port, host, options);
 }
 
 util.inherits(RedisStore, TokenStore);


### PR DESCRIPTION
Pass the arguments of the constructor into redis.createClient() without modification. This uses then the settings from redis, if arguments are undefined.
