### PR TITLE
Added option to specify an existing redis client upon initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ passwordless.addDelivery(
     function(tokenToSend, uidToSend, recipient, callback) {
         // Send out a token
     });
-    
+
 app.use(passwordless.sessionSupport());
 app.use(passwordless.acceptToken());
 ```
@@ -34,13 +34,26 @@ new RedisStore([port], [host], [options]);
 ```
 * **[port]:** *(Number)* Optional. Port of your Redis server. Defaults to: 6379
 * **[host]:** *(String)* Optional. Your Redis server. Defaults to: '127.0.0.1'
-* **[options]:** *(Object)* Optional. This can include options of the node.js Redis client as described in the [docs](https://github.com/mranney/node_redis) and the ones described below combined in one object as shown in the example
+* **[options]:** *(Object)* Optional. This can include options of the node.js Redis client as described in the [docs](https://github.com/mranney/node_redis) OR an existing Redis client, and RedisStore options as described below combined in one object as shown in the example
 
 Example:
 ```javascript
 passwordless.init(new RedisStore(6379, '127.0.0.1', {
 	// option of the node.js redis client
     auth_pass: 'password',
+    // options of RedisStore
+    redisstore: {
+        database: 15,
+        tokenkey: 'token:'
+    }
+}));
+```
+
+With existing client:
+```javascript
+passwordless.init(new RedisStore(null, null, {
+	// existing Redis client
+    client: myClient,
     // options of RedisStore
     redisstore: {
         database: 15,

--- a/lib/redisstore.js
+++ b/lib/redisstore.js
@@ -12,10 +12,12 @@ var async = require('async');
  * @param {String} [host] Host, e.g. 127.0.0.1 (default: 127.0.0.1)
  * @param {Object} [options] Combines both the options for the Redis client as well
  * as the options for RedisStore. For the Redis options please refer back to
- * the documentation: https://github.com/NodeRedis/node_redis. RedisStore accepts
- * the following options: (1) { redisstore: { database: Number }} number of the 
- * Redis database to use (default: 0), (2) { redisstore: { tokenkey: String }} the
- * prefix used for the RedisStore entries in the database (default: 'pwdless:')
+ * the documentation: https://github.com/NodeRedis/node_redis. If the `client` option
+ * is provided with existing Redis client, it will override the port/host arguments
+ * and any other Redis options.
+ * RedisStore accepts the following options: (1) { redisstore: { database: Number }}
+ * number of the Redis database to use (default: 0), (2) { redisstore: { tokenkey: String }}
+ * the prefix used for the RedisStore entries in the database (default: 'pwdless:')
  * @constructor
  */
 function RedisStore(port, host, options) {
@@ -34,7 +36,7 @@ function RedisStore(port, host, options) {
 	this._tokenKey = this._options.redisstore.tokenkey || 'pwdless:';
 	delete this._options.redisstore;
 
-	this._client = redis.createClient(port, host, this._options);
+	this._client = this._options.client || redis.createClient(port, host, this._options);
 }
 
 util.inherits(RedisStore, TokenStore);

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "async": "^2.0.0-rc.2",
-    "bcrypt": "^0.8.3",
+    "bcrypt": "^3.0.0",
     "passwordless-tokenstore": "0.0.10",
     "redis": "^2.5.3"
   },

--- a/test/redisstore.js
+++ b/test/redisstore.js
@@ -54,6 +54,12 @@ describe('Specific tests', function() {
 		expect(function() { new RedisStore(6379, '127.0.0.1') }).to.not.throw();
 	})
 
+	it('should allow the instantiation with an existing client', function () {
+		var rs = null
+		expect(function() { rs = new RedisStore(null, null, { client: 'my-client' }) }).to.not.throw();
+		expect(rs._client).to.equal('my-client');
+	})
+
 	it('should allow the instantiation with a number passed as DB selector', function () {
 		expect(function() { new RedisStore(null, null, {redisstore : { database: 0}}) }).to.not.throw();
 	})
@@ -70,8 +76,8 @@ describe('Specific tests', function() {
 		var store = new RedisStore();
 
 		var user = chance.email();
-		store.storeOrUpdate(uuid.v4(), user, 
-			1000*60, 'http://' + chance.domain() + '/page.html', 
+		store.storeOrUpdate(uuid.v4(), user,
+			1000*60, 'http://' + chance.domain() + '/page.html',
 			function() {
 				client.select(0, function(err, res) {
 					expect(err).to.not.exist;
@@ -92,22 +98,22 @@ describe('Specific tests', function() {
 		var store = new RedisStore(null, null, { redisstore : { tokenkey: 'another_name_', database: db }});
 
 		var user = chance.email();
-		store.storeOrUpdate(uuid.v4(), user, 
-			1000*60, 'http://' + chance.domain() + '/page.html', 
+		store.storeOrUpdate(uuid.v4(), user,
+			1000*60, 'http://' + chance.domain() + '/page.html',
 			function() {
 				client.hgetall('another_name_' + user, function(err, obj) {
 					expect(err).to.not.exist;
 					expect(obj).to.exist;
 					done();
 				})
-			});		
+			});
 	});
 
 	it('should default to "pwdless:" as token key', function(done) {
 		var store = TokenStoreFactory();
 		var user = chance.email();
-		store.storeOrUpdate(uuid.v4(), user, 
-			1000*60, 'http://' + chance.domain() + '/page.html', 
+		store.storeOrUpdate(uuid.v4(), user,
+			1000*60, 'http://' + chance.domain() + '/page.html',
 			function() {
 				client.hgetall('pwdless:' + user, function(err, obj) {
 					expect(err).to.not.exist;
@@ -121,8 +127,8 @@ describe('Specific tests', function() {
 		var store = TokenStoreFactory();
 		var user = chance.email();
 		var token = uuid.v4();
-		store.storeOrUpdate(token, user, 
-			1000*60, 'http://' + chance.domain() + '/page.html', 
+		store.storeOrUpdate(token, user,
+			1000*60, 'http://' + chance.domain() + '/page.html',
 			function() {
 				client.hgetall('pwdless:' + user, function(err, obj) {
 					expect(err).to.not.exist;
@@ -139,16 +145,16 @@ describe('Specific tests', function() {
 		var user = chance.email();
 		var token = uuid.v4();
 		var hashedToken1;
-		store.storeOrUpdate(token, user, 
-			1000*60, 'http://' + chance.domain() + '/page.html', 
+		store.storeOrUpdate(token, user,
+			1000*60, 'http://' + chance.domain() + '/page.html',
 			function() {
 				client.hgetall('pwdless:' + user, function(err, obj) {
 					expect(err).to.not.exist;
 					expect(obj).to.exist;
 					expect(obj.token).to.exist;
 					hashedToken1 = obj.token;
-					store.storeOrUpdate(token, user, 
-						1000*60, 'http://' + chance.domain() + '/page.html', 
+					store.storeOrUpdate(token, user,
+						1000*60, 'http://' + chance.domain() + '/page.html',
 						function() {
 							client.hgetall('pwdless:' + user, function(err, obj) {
 								expect(err).to.not.exist;
@@ -156,9 +162,9 @@ describe('Specific tests', function() {
 								expect(obj.token).to.exist;
 								expect(obj.token).to.not.equal(hashedToken1);
 								done();
-							});						
+							});
 						});
 				})
-			});		
+			});
 	});
 })


### PR DESCRIPTION
Added an option to specify an existing redis client upon initialization, added tests and updated readme and comments. Also upgraded `bcrypt` to avoid known vulnerabilities (won't pass npm install without this upgrade).